### PR TITLE
Add LCOW scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ This repo is a collection of various Vagrant environments to work with Windows C
 
 There are different Vagrantfiles for each scenario:
 
-* `Vagrantfile` - Windows Server 2016 and Docker 17.03.1-ee
+* `Vagrantfile` - Windows Server 2016 and Docker 17.10.0-ce
+* [`lcow/Vagrantfile`](lcow/README.md) - Windows 10 1709 with nightly Docker and LCOW enabled
 * [`nano/Vagrantfile`](nano/README.md) - Test setup to have Docker engine installed in a Windows Nanoserver VM
 * [`swarm-demo/Vagrantfile`](swarm-demo/README.md) - some Windows Server 2016 VM's in classical Docker Swarm
 * [`swarm-mode/Vagrantfile`](swarm-mode/README.md) - some Windows Server 2016 VM's in Docker Swarm-mode and overlay network
-* [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 and Docker 17.03.0-ce natively installed (see [docker-windows-beta](https://github.com/StefanScherer/docker-windows-beta)  repo if you want to try Docker 4 Windows instead)
+* [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 and Docker 17.10.0-ce natively installed (see [docker-windows-beta](https://github.com/StefanScherer/docker-windows-beta) repo if you want to try Docker 4 Windows instead)
 
 ## Introduction
 
@@ -20,9 +21,9 @@ Have a look at my blog posts how to [Setup a local Windows 2016 TP5 Docker VM](h
 
 After provisioning the box has the following tools installed:
 
-* Windows Server 2016 with Docker Engine 17.03.1-ee and client
-* docker-machine 0.10.0
-* docker-compose 1.12.0
+* Windows Server 2016 with Docker Engine 17.10.0-ce and client
+* docker-machine 0.13.0
+* docker-compose 1.18.0
 * (Docker Tab completion for PowerShell (posh-docker))
 * Chocolatey
 * Git command line
@@ -44,9 +45,11 @@ Future work will be a Docker Swarm with both Linux and Windows Docker Engines...
 First register to [evaluate Windows 2016](https://www.microsoft.com/evalcenter/evaluate-windows-server-2016), but you don't need to download the ISO manually.
 
 For the next step you need [Packer](https://packer.io). You have several ways how to install it. The easiest way is to install it via [Homebrew](http://brew.sh/). After you have installed Homebrew. Run the following command when you installed Homebrew:
+
 ```bash
 brew install packer
 ```
+
 If you don't have the Vagrant `windows_2016_docker` base box you need to create it first with [Packer](https://packer.io). See my [packer-windows](https://github.com/StefanScherer/packer-windows) repo to build the base box.
 
 To build the base box you have to run these commands on your host machine:

--- a/lcow/README.md
+++ b/lcow/README.md
@@ -1,0 +1,37 @@
+# LCOW
+
+Linux Containers on Windows (LCOW) works on Windows 10 1709 and a Docker
+engine that has the pull request [moby/moby#34859](https://github.com/moby/moby/pull/34859)
+merged in.
+
+At the moment we can use the nightly builds from [master.dockerproject.com](https://master.dockerproject.com).
+
+To run Linux containers we also need a small Linux VM which is part of the Docker EE 17.10 Preview.
+
+## Create the VM
+
+```
+vagrant up
+```
+
+## Run Windows containers
+
+In the Windows 10 VM open a PowerShell terminal.
+
+```
+docker run microsoft/nanoserver:1709 cmd /c set
+```
+
+## Run Linux containers
+
+At the moment you need to specify the `--platform` option to pull Linux images.
+
+```
+docker pull --platform linux alpine
+```
+
+Once you have pulled Linux images you can run them without the `--platform` option.
+
+```
+docker run alpine uname -a
+```

--- a/lcow/Vagrantfile
+++ b/lcow/Vagrantfile
@@ -1,0 +1,55 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "StefanScherer/windows_10"
+
+  config.vm.hostname = "lcow"
+  config.vm.communicator = "winrm"
+
+  config.winrm.username = "vagrant"
+  config.winrm.password = "vagrant"
+
+  config.vm.guest = :windows
+  config.windows.halt_timeout = 15
+
+  config.vm.provision "shell", path: "scripts/install-container-feature.ps1", privileged: true
+  config.vm.provision "shell", path: "scripts/enable-autologon.ps1", privileged: true
+  config.vm.provision "shell", path: "scripts/set-path.ps1", privileged: true
+  config.vm.provision "reload"
+  config.vm.provision "shell", path: "scripts/add-docker-group.ps1", privileged: true
+  config.vm.provision "shell", path: "scripts/install-docker.ps1", privileged: true
+  config.vm.provision "shell", path: "scripts/install-chocolatey.ps1", privileged: false
+  config.vm.provision "shell", path: "scripts/install-dockertools.ps1", privileged: false
+
+  ["vmware_fusion", "vmware_workstation"].each do |provider|
+    config.vm.provider provider do |v, override|
+      v.gui = true
+      v.memory = 5120
+      v.cpus = 2
+    end
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["gui.fitguestusingnativedisplayresolution"] = "TRUE"
+    v.vmx["mks.enable3d"] = "TRUE"
+    v.vmx["mks.forceDiscreteGPU"] = "TRUE"
+    v.vmx["gui.fullscreenatpoweron"] = "TRUE"
+    v.vmx["gui.viewmodeatpoweron"] = "fullscreen"
+    v.vmx["gui.lastPoweredViewMode"] = "fullscreen"
+    v.vmx["sound.startconnected"] = "TRUE"
+    v.vmx["sound.present"] = "TRUE"
+    v.vmx["sound.autodetect"] = "TRUE"
+    v.enable_vmrun_ip_lookup = false
+    v.vmx["vhv.enable"] = "TRUE"
+    v.vmx["hgfs.linkRootShare"] = "FALSE"
+  end
+
+  config.vm.provider "vcloud" do |v|
+    v.memory = 5120
+    v.cpus = 2
+    v.nested_hypervisor = true
+  end
+end

--- a/lcow/scripts/add-docker-group.ps1
+++ b/lcow/scripts/add-docker-group.ps1
@@ -1,0 +1,2 @@
+net localgroup docker /add
+net localgroup docker vagrant /add

--- a/lcow/scripts/enable-autologon.ps1
+++ b/lcow/scripts/enable-autologon.ps1
@@ -1,0 +1,3 @@
+Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AutoAdminLogon -Value 1
+Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultUserName -Value "vagrant"
+Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultPassword -Value "vagrant"

--- a/lcow/scripts/install-chocolatey.ps1
+++ b/lcow/scripts/install-chocolatey.ps1
@@ -1,0 +1,3 @@
+# install chocolatey
+iex (wget 'https://chocolatey.org/install.ps1' -UseBasicParsing)
+choco feature disable --name showDownloadProgress

--- a/lcow/scripts/install-container-feature.ps1
+++ b/lcow/scripts/install-container-feature.ps1
@@ -1,0 +1,3 @@
+# https://msdn.microsoft.com/de-de/virtualization/windowscontainers/quick_start/quick_start_windows_10
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart

--- a/lcow/scripts/install-docker.ps1
+++ b/lcow/scripts/install-docker.ps1
@@ -1,0 +1,17 @@
+Set-ExecutionPolicy Bypass -scope Process
+$ProgressPreference = 'SilentlyContinue';
+
+Write-Host "Downloading docker preview with Linux containers ..."
+Invoke-WebRequest -OutFile "$env:TEMP\docker-17.10.0-ee-preview-3.zip" "https://download.docker.com/components/engine/windows-server/preview/docker-17.10.0-ee-preview-3.zip"
+Expand-Archive -Path "$env:TEMP\docker-17.10.0-ee-preview-3.zip" -DestinationPath $env:ProgramFiles -Force
+Remove-Item "$env:TEMP\docker-17.10.0-ee-preview-3.zip"
+
+Write-Host "Downloading docker nightly ..."
+Invoke-WebRequest -OutFile "$env:TEMP\docker-master.zip" "https://master.dockerproject.com/windows/x86_64/docker.zip"
+Expand-Archive -Path "$env:TEMP\docker-master.zip" -DestinationPath $env:ProgramFiles -Force
+Remove-Item "$env:TEMP\docker-master.zip"
+
+$env:Path = $env:Path + ";$($env:ProgramFiles)\docker"
+Write-Host "Registering docker service ..."
+. dockerd --register-service -H npipe:// -H 0.0.0.0:2375 -G docker --experimental
+Start-Service Docker

--- a/lcow/scripts/install-dockertools.ps1
+++ b/lcow/scripts/install-dockertools.ps1
@@ -1,0 +1,3 @@
+# install docker tools
+choco install -y docker-machine
+choco install -y docker-compose

--- a/lcow/scripts/set-path.ps1
+++ b/lcow/scripts/set-path.ps1
@@ -1,0 +1,1 @@
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$($env:ProgramFiles)\docker", [EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
# LCOW

Linux Containers on Windows (LCOW) works on Windows 10 1709 and a Docker
engine that has the pull request [moby/moby#34859](https://github.com/moby/moby/pull/34859)
merged in.

At the moment we can use the nightly builds from [master.dockerproject.com](https://master.dockerproject.com).

To run Linux containers we also need a small Linux VM which is part of the Docker EE 17.10 Preview.

## Create the VM

```
vagrant up
```

## Run Windows containers

In the Windows 10 VM open a PowerShell terminal.

```
docker run microsoft/nanoserver:1709 cmd /c set
```

## Run Linux containers

At the moment you need to specify the `--platform` option to pull Linux images.

```
docker pull --platform linux alpine
```

Once you have pulled Linux images you can run them without the `--platform` option.

```
docker run alpine uname -a
```
