### PR TITLE
Add test environment for docker-machine and VMware Workstation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ There are different Vagrantfiles for each scenario:
 * [`swarm-demo/Vagrantfile`](swarm-demo/README.md) - some Windows Server 2016 VM's in classical Docker Swarm
 * [`swarm-mode/Vagrantfile`](swarm-mode/README.md) - some Windows Server 2016 VM's in Docker Swarm-mode and overlay network
 * [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 and Docker 17.10.0-ce natively installed (see [docker-windows-beta](https://github.com/StefanScherer/docker-windows-beta) repo if you want to try Docker 4 Windows instead)
+* [`docker-machine/Vagrantfile`](docker-machine/README.md) - Windows 10 with `docker-machine` installed to test with VMware Workstation
 
 ## Introduction
 

--- a/docker-machine/README.md
+++ b/docker-machine/README.md
@@ -1,0 +1,52 @@
+# docker-machine test environment
+
+Run a Windows 10 VM to test `docker-machine` and nested boot2docker Linux VM's and Linux containers.
+
+## Create environment
+
+Adjust the versions in the Vagrantfile for the Windows VM to be used, VMware Workstation, docker-machine and the docker CLI. Then run
+
+```
+vagrant up
+```
+
+## Test to create a Docker machine
+
+Now inside the VM - either with `vagrant rdp` or just using the desktop of the visible VM.
+
+First you have to enter a valid VMware Workstation license or start the 30 days trial.
+
+Then open a PowerShell terminal ( `Win`+ `R` and enter `powershell` ).
+
+Then run this command and specify the version of the boot2docker URL.
+
+```
+docker-machine create -d vmwareworkstation --vmwareworkstation-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v18.06.1-ce/boot2docker.iso
+```
+
+If that works try if the shared folder is mounted in the boot2docker VM:
+
+```
+docker-machine env test | iex
+docker-machine ssh test ls /Users
+```
+
+If that also works try to run a container with a shared folder mounted:
+
+```
+docker-machine env test | iex
+docker run --rm -v "/Users/vagrant:/code" alpine ls /code
+```
+
+If that also works you found a working combination.
+
+## Current status
+
+This combination works fine
+
+- docker-machine 0.13.0
+- boot2docker 18.06.1
+
+## See also
+
+- https://github.com/boot2docker/boot2docker/pull/1350

--- a/docker-machine/Vagrantfile
+++ b/docker-machine/Vagrantfile
@@ -1,0 +1,36 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "StefanScherer/windows_10"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    iwr -useb https://chocolatey.org/install.ps1 | iex
+    choco install -y vmwareworkstation -version 15.0.1
+    choco install -y docker -version 17.10.0
+    choco install -y docker-machine -version 0.13.0
+    choco install -y docker-machine-vmwareworkstation
+  SHELL
+  
+  ["vmware_fusion", "vmware_workstation"].each do |provider|
+    config.vm.provider provider do |v, override|
+      v.gui = true
+      v.memory = 4096
+      v.cpus = 2
+      v.vmx["vhv.enable"] = "TRUE"
+      v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["gui.fitguestusingnativedisplayresolution"] = "TRUE"
+    v.vmx["mks.enable3d"] = "TRUE"
+    v.vmx["mks.forceDiscreteGPU"] = "TRUE"
+    v.vmx["gui.fullscreenatpoweron"] = "TRUE"
+    v.vmx["gui.viewmodeatpoweron"] = "fullscreen"
+    v.vmx["gui.lastPoweredViewMode"] = "fullscreen"
+    v.vmx["sound.startconnected"] = "TRUE"
+    v.vmx["sound.present"] = "TRUE"
+    v.vmx["sound.autodetect"] = "TRUE"
+  end
+end


### PR DESCRIPTION
To test https://github.com/boot2docker/boot2docker/pull/1350 not only on macOS and VMware Fusion I created a Windows 10 test environment. Chocolatey helps here to reduce the setup in only a few lines.
