### PR TITLE
Add test environment for docker-machine and VMware Fusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ There are different Vagrantfiles for each scenario:
 * [`swarm-demo/Vagrantfile`](swarm-demo/README.md) - some Windows Server 2016 VM's in classical Docker Swarm
 * [`swarm-mode/Vagrantfile`](swarm-mode/README.md) - some Windows Server 2016 VM's in Docker Swarm-mode and overlay network
 * [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 and Docker 17.10.0-ce natively installed (see [docker-windows-beta](https://github.com/StefanScherer/docker-windows-beta) repo if you want to try Docker 4 Windows instead)
-* [`docker-machine/Vagrantfile`](docker-machine/README.md) - Windows 10 with `docker-machine` installed to test with VMware Workstation
+* docker-machine test environments
+  * [`docker-machine/Vagrantfile`](docker-machine/README.md) - Windows 10 with `docker-machine` installed to test with VMware Workstation
+  * [`docker-machine-fusion/Vagrantfile`](docker-machine-fusion/README.md) - macOS 10.13 with `docker-machine` installed to test with VMware Fusion
 
 ## Introduction
 

--- a/docker-machine-fusion/README.md
+++ b/docker-machine-fusion/README.md
@@ -1,0 +1,68 @@
+# docker-machine test environment
+
+Run a macOS VM to test `docker-machine` and nested boot2docker Linux VM's and Linux containers.
+
+## Create environment
+
+Adjust the versions in the Vagrantfile for the macOS VM to be used, VMware Fusion, docker-machine and the docker CLI. Then run
+
+```
+vagrant up
+```
+
+## Test to create a Docker machine
+
+Now inside the VM - either with `vagrant rdp` or just using the desktop of the visible VM.
+
+First you have to enter a valid VMware Fusion license or start the 30 days trial.
+To install and/or use vmware-fusion you may need to enable their kernel extension in
+
+  System Preferences → Security & Privacy → General
+
+Then open a Terminal.
+
+Then run this command and specify the version of the boot2docker URL. There are several versions of docker-machine downloaded (0.13.0 to 0.16.0).
+
+```
+docker-machine-0.13.0 -D create -d vmwarefusion --vmwarefusion-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v18.06.1-ce/boot2docker.iso test
+```
+
+During the creation you can see the boot2docker VM by opening the vmx file:
+
+```
+open ~/.docker/machine/machines/test/test.vmx
+```
+
+If that works try if the shared folder is mounted in the boot2docker VM:
+
+```
+docker-machine ssh test ls /Users
+```
+
+If that also works try to run a container with a shared folder mounted:
+
+```
+eval $(docker-machine env test)
+docker run --rm -v /Users:/Users alpine ls /Users
+```
+
+If that also works you found a working combination.
+
+To try another boot2docker version destroy the current docker machine:
+
+```
+docker-machine rm -f test
+```
+
+## Current status
+
+This combination works fine
+
+- docker-machine 0.13.0 with `vmwarefusion` driver
+- boot2docker 18.06.1
+
+Any newer docker-machine binary does not work and aborts at vmrun enableSharedFolders.
+
+## See also
+
+- https://github.com/boot2docker/boot2docker/pull/1350

--- a/docker-machine-fusion/Vagrantfile
+++ b/docker-machine-fusion/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "osx1013-desktop"
+  config.ssh.insert_key = false
+
+  config.vm.provision "shell", inline: <<-SHELL, privileged: false
+    printf "\n\n" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    brew cask install vmware-fusion
+    brew install docker
+    brew install docker-machine
+    curl -Lo /usr/local/bin/docker-machine-0.13.0 https://github.com/docker/machine/releases/download/v0.13.0/docker-machine-Darwin-x86_64
+    curl -Lo /usr/local/bin/docker-machine-0.14.0 https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-Darwin-x86_64
+    curl -Lo /usr/local/bin/docker-machine-0.15.0 https://github.com/docker/machine/releases/download/v0.15.0/docker-machine-Darwin-x86_64
+    curl -Lo /usr/local/bin/docker-machine-0.16.0 https://github.com/docker/machine/releases/download/v0.16.0/docker-machine-Darwin-x86_64
+    chmod +x /usr/local/bin/docker-machine-*    
+  SHELL
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.gui = true
+    v.vmx["memsize"] = "4096"
+    v.vmx["numvcpus"] = "2"
+    v.vmx["vhv.enable"] = "TRUE"
+    v.vmx["gui.fitguestusingnativedisplayresolution"] = "TRUE"
+  end
+end

--- a/docker-machine/README.md
+++ b/docker-machine/README.md
@@ -33,7 +33,6 @@ start C:\Users\vagrant\.docker\machine\machines\test\test.vmx
 If that works try if the shared folder is mounted in the boot2docker VM:
 
 ```
-docker-machine env test | iex
 docker-machine ssh test ls /Users
 ```
 
@@ -41,7 +40,7 @@ If that also works try to run a container with a shared folder mounted:
 
 ```
 docker-machine env test | iex
-docker run --rm -v "/Users/vagrant:/code" alpine ls /code
+docker run --rm -v /Users:/Users alpine ls /Users
 ```
 
 If that also works you found a working combination.


### PR DESCRIPTION
To test boot2docker/boot2docker#1350 on macOS and VMware Fusion I created a macOS 10.13 test environment. Brew and curl help here to reduce the setup in only a few lines.
