### PR TITLE
Add Windows 10 1809 + process isolation test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are different Vagrantfiles for each scenario:
 * [`nano/Vagrantfile`](nano/README.md) - Test setup to have Docker engine installed in a Windows Nanoserver VM
 * [`swarm-demo/Vagrantfile`](swarm-demo/README.md) - some Windows Server 2016 VM's in classical Docker Swarm
 * [`swarm-mode/Vagrantfile`](swarm-mode/README.md) - some Windows Server 2016 VM's in Docker Swarm-mode and overlay network
-* [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 and Docker 17.10.0-ce natively installed (see [docker-windows-beta](https://github.com/StefanScherer/docker-windows-beta) repo if you want to try Docker 4 Windows instead)
+* [`windows10/Vagrantfile`](windows10/README.md) - Windows 10 1809 and nightly Docker to test process isolation
 * docker-machine test environments
   * [`docker-machine/Vagrantfile`](docker-machine/README.md) - Windows 10 with `docker-machine` installed to test with VMware Workstation
   * [`docker-machine-fusion/Vagrantfile`](docker-machine-fusion/README.md) - macOS 10.13 with `docker-machine` installed to test with VMware Fusion

--- a/windows10/README.md
+++ b/windows10/README.md
@@ -1,12 +1,21 @@
 # Docker on Windows 10
 
-This `Vagrantfile` installs Docker Engine on Windows 10 1709 or newer
+This `Vagrantfile` installs the nightly Docker Engine on Windows 10 1809 or newer
 as described in https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_10
 
-You need a Vagrant box with Windows 10 1709.
+You need a Vagrant box with Windows 10 1809.
 
 ```
 vagrant up
+```
+
+## Run Windows containers with process isolation
+
+With Pull request [38000](https://github.com/moby/moby/pull/38000) the process isolation is also allowed for Windows 10 1809 and newer. At the moment the nightly Docker Engine is needed until
+it gets [backported to 18.09](https://github.com/docker/engine/pull/81).
+ 
+```
+docker run --isolation process mcr.microsoft.com/windows/nanoserver:1809 ipconfig
 ```
 
 ## Docker Swarm-Mode with Linux and Windows

--- a/windows10/scripts/install-docker.ps1
+++ b/windows10/scripts/install-docker.ps1
@@ -1,9 +1,9 @@
 Set-ExecutionPolicy Bypass -scope Process
 New-Item -Type Directory -Path "$($env:ProgramFiles)\docker"
-Write-Host "Downloading docker ..."
-wget -outfile $env:TEMP\docker.zip "https://download.docker.com/win/static/edge/x86_64/docker-17.10.0-ce.zip"
+Write-Host "Downloading docker nightly build ..."
+wget -outfile $env:TEMP\docker.zip "https://master.dockerproject.com/windows/x86_64/docker.zip"
 Expand-Archive -Path $env:TEMP\docker.zip -DestinationPath $env:TEMP -Force
-copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
+copy $env:TEMP\docker\*.* $env:ProgramFiles\docker
 Remove-Item $env:TEMP\docker.zip
 [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$($env:ProgramFiles)\docker", [EnvironmentVariableTarget]::Machine)
 $env:Path = $env:Path + ";$($env:ProgramFiles)\docker"


### PR DESCRIPTION
Test process isolation in a Windows 10 1809 box. We need nightly Docker Engine right now.
