### PR TITLE
Copy Required DLLs to $env:ProgramFiles\docker

### DIFF
--- a/scripts/install-docker.ps1
+++ b/scripts/install-docker.ps1
@@ -27,6 +27,7 @@ if ($docker_provider -eq "ce") {
   wget -outfile $env:TEMP\docker.zip $("https://dockermsft.blob.core.windows.net/dockercontainer/docker-{0}.zip" -f $docker_version)
   Expand-Archive -Path $env:TEMP\docker.zip -DestinationPath $env:TEMP -Force
   copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
+  copy $env:TEMP\docker\*.dll $env:ProgramFiles\docker
   Remove-Item $env:TEMP\docker.zip
   [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$($env:ProgramFiles)\docker", [EnvironmentVariableTarget]::Machine)
   $env:Path = $env:Path + ";$($env:ProgramFiles)\docker"


### PR DESCRIPTION
Installing docker threw an error when trying to register the service - it looks like docker now needs some DLLs copied into the folder as well to allow the command to run.